### PR TITLE
Add Dakera: self-hosted HNSW vector memory server for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -837,6 +837,7 @@ The public-facing website is based on the open-source [Directory Website Templat
 ## AI Agent Memory Stores
 
 - [Supermemory](https://supermemory.ai/) - State-of-the-art AI agent memory system using ASMR technique that achieved ~99% accuracy on LongMemEval benchmark with multi-agent orchestrated pipeline. ([Read more](/details/supermemory.md)) `agent-memory` `2026 Trends` `RAG Optimized`
+- [Dakera](https://github.com/dakera-ai/dakera-mcp) - Self-hosted agent memory server built on HNSW vector search with RocksDB persistence. MCP-native interface, decay-weighted recall, production-ready for AI agent workflows. `agent-memory` `self-hosted` `MCP` `HNSW`
 
 ## Benchmark & Eval Tools
 


### PR DESCRIPTION
## Summary

Adds [Dakera](https://github.com/dakera-ai/dakera-mcp) to the **AI Agent Memory Stores** section — a natural fit alongside existing entries in that category.

Dakera is a self-hosted MCP-native agent memory server built on HNSW vector search with RocksDB-backed persistence. It is designed for production AI agent workflows where agents need to persist, retrieve, and share knowledge across sessions. Decay-weighted recall ensures that older, less-relevant memories naturally fade while recent context stays prominent.

Distinct from general-purpose vector databases: Dakera is opinionated toward agent memory primitives (store, recall, forget, cross-agent share) with multi-agent namespacing and an MCP interface that plugs directly into Claude, Cursor, and compatible agent runtimes.