### PR TITLE
feat: add TWZRD Agent Intel to AI Agent Memory Stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -836,6 +836,7 @@ The public-facing website is based on the open-source [Directory Website Templat
 
 ## AI Agent Memory Stores
 
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust scoring and identity verification for AI agents on Solana. Free MCP tools (score_agent, preflight_check) return on-chain reputation scores before x402 micropayments; paid get_trust_receipt issues a cryptographic receipt. Config: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}` `agent-identity` `mcp` `x402` `solana` `trust`
 - [Supermemory](https://supermemory.ai/) - State-of-the-art AI agent memory system using ASMR technique that achieved ~99% accuracy on LongMemEval benchmark with multi-agent orchestrated pipeline. ([Read more](/details/supermemory.md)) `agent-memory` `2026 Trends` `RAG Optimized`
 
 ## Benchmark & Eval Tools


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **AI Agent Memory Stores** section.

TWZRD Agent Intel is a trust scoring and identity verification MCP server for AI agents operating on Solana. Before an agent makes an x402 micropayment or delegates a task, it can call `score_agent(wallet)` or `preflight_check(wallet)` (both free) to retrieve on-chain reputation data. `get_trust_receipt(wallet)` (paid) issues a cryptographic receipt.

**MCP config:**
```json
{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}
```

Relevant to this list because it provides the *trust layer* for agent-to-agent and human-to-agent interactions, using the Solana ledger as an immutable audit trail for agent identity and activity.